### PR TITLE
[Update]攻撃と防御の切り替え、操作方法の切り替え（自動、手動）、主人公パラメータ数の更新

### DIFF
--- a/Assets/Scenes/Develop/Credit.unity
+++ b/Assets/Scenes/Develop/Credit.unity
@@ -1,0 +1,677 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 3
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 0
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &420979823
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 420979824}
+  - component: {fileID: 420979826}
+  - component: {fileID: 420979825}
+  m_Layer: 5
+  m_Name: Panel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &420979824
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 420979823}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.1, y: 1.1, z: 1.1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1106721550}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &420979825
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 420979823}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &420979826
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 420979823}
+  m_CullTransparentMesh: 1
+--- !u!1 &768652482
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 768652484}
+  - component: {fileID: 768652483}
+  m_Layer: 0
+  m_Name: GameObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!320 &768652483
+PlayableDirector:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 768652482}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_PlayableAsset: {fileID: 11400000, guid: 85591621c01aeb24fb1d1dbdac062964, type: 2}
+  m_InitialState: 1
+  m_WrapMode: 2
+  m_DirectorUpdateMode: 1
+  m_InitialTime: 0
+  m_SceneBindings:
+  - key: {fileID: 2965896489710579418, guid: 85591621c01aeb24fb1d1dbdac062964, type: 2}
+    value: {fileID: 1098302400}
+  m_ExposedReferences:
+    m_References: []
+--- !u!4 &768652484
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 768652482}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -3.2462876, y: -0.4724111, z: 0.031808645}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1098302399
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1098302403}
+  - component: {fileID: 1098302402}
+  - component: {fileID: 1098302401}
+  - component: {fileID: 1098302400}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!95 &1098302400
+Animator:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1098302399}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: 97225f973dd5e4648b61ac8f740922eb, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
+--- !u!114 &1098302401
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1098302399}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "\u30C7\u30A3\u30EC\u30AF\u30BF\u30FC\n\n\u83C5\u6CBC\n\n\u30D7\u30ED\u30B8\u30A7\u30AF\u30C8\u30EA\u30FC\u30C0\u30FC\n\n\u8D64\u5742\n\n\u30D7\u30E9\u30F3\u30CA\u30FC\u30EA\u30FC\u30C0\u30FC\n\n\u5DE5\u85E4\n\n\u30D7\u30ED\u30B0\u30E9\u30E0\u30EA\u30FC\u30C0\u30FC\n\n\u5DDD\u53E3\n\n\u30D7\u30E9\u30F3\u30CA\u30FC\n\n\u30D7\u30ED\u30B0\u30E9\u30DE\u30FC\n\n\u8584\u8863\n\n\u30C7\u30B6\u30A4\u30CA\u30FC\n\n\u30B5\u30A6\u30F3\u30C9\u30AF\u30EA\u30A8\u30A4\u30BF\u30FC\n\nSpecialThanks\n\n\u5916\u5C71"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 100
+  m_fontSizeBase: 100
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 0
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1098302402
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1098302399}
+  m_CullTransparentMesh: 1
+--- !u!224 &1098302403
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1098302399}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1106721550}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1106721546
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1106721550}
+  - component: {fileID: 1106721549}
+  - component: {fileID: 1106721548}
+  - component: {fileID: 1106721547}
+  m_Layer: 5
+  m_Name: Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1106721547
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1106721546}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &1106721548
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1106721546}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!223 &1106721549
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1106721546}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 25
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!224 &1106721550
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1106721546}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 420979824}
+  - {fileID: 1098302403}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!1 &1405885591
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1405885594}
+  - component: {fileID: 1405885593}
+  - component: {fileID: 1405885592}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &1405885592
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1405885591}
+  m_Enabled: 1
+--- !u!20 &1405885593
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1405885591}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 1
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &1405885594
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1405885591}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1683412546
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1683412549}
+  - component: {fileID: 1683412548}
+  - component: {fileID: 1683412547}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1683412547
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1683412546}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_SendPointerHoverToParent: 1
+  m_HorizontalAxis: Horizontal
+  m_VerticalAxis: Vertical
+  m_SubmitButton: Submit
+  m_CancelButton: Cancel
+  m_InputActionsPerSecond: 10
+  m_RepeatDelay: 0.5
+  m_ForceModuleActive: 0
+--- !u!114 &1683412548
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1683412546}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+--- !u!4 &1683412549
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1683412546}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 1405885594}
+  - {fileID: 1106721550}
+  - {fileID: 1683412549}
+  - {fileID: 768652484}

--- a/Assets/Scenes/Develop/Credit.unity.meta
+++ b/Assets/Scenes/Develop/Credit.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 56dcf48850a059543bbd42326b4d050e
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Develop/Exam.unity
+++ b/Assets/Scenes/Develop/Exam.unity
@@ -398,7 +398,8 @@ MonoBehaviour:
   _viewId: ExamUI
   _soulText: {fileID: 0}
   _waveText: {fileID: 1465307408}
-  _TimerText: {fileID: 670500554}
+  _timerText: {fileID: 670500554}
+  _operationText: {fileID: 1996913775}
 --- !u!225 &427468178
 CanvasGroup:
   m_ObjectHideFlags: 0
@@ -491,6 +492,7 @@ RectTransform:
   - {fileID: 724289213}
   - {fileID: 1073001645}
   - {fileID: 2063543467}
+  - {fileID: 1859169990}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -498,85 +500,75 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
---- !u!1 &441846288
-GameObject:
+--- !u!1001 &490317152
+PrefabInstance:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 441846289}
-  - component: {fileID: 441846291}
-  - component: {fileID: 441846290}
-  m_Layer: 5
-  m_Name: Text (Legacy) (1)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &441846289
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 441846288}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1073001645}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 140.98}
-  m_SizeDelta: {x: 160, y: 30}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &441846290
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 441846288}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0, g: 0, b: 0, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_FontData:
-    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 100
-    m_FontStyle: 1
-    m_BestFit: 0
-    m_MinSize: 1
-    m_MaxSize: 100
-    m_Alignment: 4
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 1
-    m_VerticalOverflow: 1
-    m_LineSpacing: 1
-  m_Text: "\u5473\u65B9"
---- !u!222 &441846291
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 441846288}
-  m_CullTransparentMesh: 1
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -8653719598885068355, guid: b81617707bef1074abdc510b377935f9,
+        type: 3}
+      propertyPath: m_Name
+      value: Battle_Character_01
+      objectReference: {fileID: 0}
+    - target: {fileID: -7552582706839291426, guid: b81617707bef1074abdc510b377935f9,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -5.83
+      objectReference: {fileID: 0}
+    - target: {fileID: -7552582706839291426, guid: b81617707bef1074abdc510b377935f9,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.95
+      objectReference: {fileID: 0}
+    - target: {fileID: -7552582706839291426, guid: b81617707bef1074abdc510b377935f9,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -7552582706839291426, guid: b81617707bef1074abdc510b377935f9,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -7552582706839291426, guid: b81617707bef1074abdc510b377935f9,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -7552582706839291426, guid: b81617707bef1074abdc510b377935f9,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -7552582706839291426, guid: b81617707bef1074abdc510b377935f9,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -7552582706839291426, guid: b81617707bef1074abdc510b377935f9,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -7552582706839291426, guid: b81617707bef1074abdc510b377935f9,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -7552582706839291426, guid: b81617707bef1074abdc510b377935f9,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 4843985084834002234, guid: b81617707bef1074abdc510b377935f9,
+    type: 3}
 --- !u!1 &670500553
 GameObject:
   m_ObjectHideFlags: 0
@@ -892,7 +884,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 141144481}
-  - {fileID: 441846289}
   m_Father: {fileID: 427468182}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -1807,6 +1798,230 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1838896687}
   m_CullTransparentMesh: 1
+--- !u!1 &1859169989
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1859169990}
+  - component: {fileID: 1859169993}
+  - component: {fileID: 1859169992}
+  - component: {fileID: 1859169991}
+  m_Layer: 5
+  m_Name: AutoButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1859169990
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1859169989}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 2, y: 2, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1996913774}
+  m_Father: {fileID: 427468182}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 160, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1859169991
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1859169989}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1859169992}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 2143643710}
+        m_TargetAssemblyTypeName: TeamB.Develop.Exam, Develop
+        m_MethodName: ChangeOperation
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 427468177}
+        m_TargetAssemblyTypeName: TeamB.UI.InExamUIView, Develop
+        m_MethodName: OperationChange
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &1859169992
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1859169989}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1859169993
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1859169989}
+  m_CullTransparentMesh: 1
+--- !u!1 &1996913773
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1996913774}
+  - component: {fileID: 1996913776}
+  - component: {fileID: 1996913775}
+  m_Layer: 5
+  m_Name: Text (Legacy)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1996913774
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1996913773}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1859169990}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1996913775
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1996913773}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 30
+    m_FontStyle: 1
+    m_BestFit: 0
+    m_MinSize: 1
+    m_MaxSize: 100
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 1
+    m_VerticalOverflow: 1
+    m_LineSpacing: 1
+  m_Text: Auto
+--- !u!222 &1996913776
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1996913773}
+  m_CullTransparentMesh: 1
 --- !u!1 &2045680101
 GameObject:
   m_ObjectHideFlags: 0
@@ -1930,7 +2145,10 @@ MonoBehaviour:
     RefIds:
     - rid: 2212115237729992705
       type: {class: Character1, ns: TeamB.Develop, asm: Develop}
-      data: 
+      data:
+        _percentageReductionValue: 0.75
+        _defenceCoolTime: 1
+        _defenceDurationTime: 1
 --- !u!4 &2124309694
 Transform:
   m_ObjectHideFlags: 0
@@ -2057,6 +2275,7 @@ GameObject:
   - component: {fileID: 2143643710}
   - component: {fileID: 2143643709}
   - component: {fileID: 2143643712}
+  - component: {fileID: 2143643713}
   m_Layer: 0
   m_Name: ExamManager
   m_TagString: Untagged
@@ -2089,6 +2308,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _examTime: 45
+  _operationType: 0
 --- !u!4 &2143643711
 Transform:
   m_ObjectHideFlags: 0
@@ -2116,29 +2336,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 109389dba1065bc44ac426ad6b27b478, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  skillData:
+  _skillData:
   - _examState: 0
     _skillState:
     - SkillType: 0
       Skill:
-        rid: 2212115243444469760
-      Target: 1
-      Cost: 2
-    - SkillType: 0
-      Skill:
-        rid: 2212115243444469761
-      Target: 1
-      Cost: 2
-  - _examState: 1
-    _skillState:
-    - SkillType: 0
-      Skill:
-        rid: 2212115243444469762
-      Target: 1
-      Cost: 2
-    - SkillType: 0
-      Skill:
-        rid: 2212115243444469763
+        rid: 2212115360025935872
       Target: 1
       Cost: 2
   _maxCost: 10
@@ -2146,22 +2349,32 @@ MonoBehaviour:
   references:
     version: 2
     RefIds:
-    - rid: 2212115243444469760
+    - rid: 2212115360025935872
       type: {class: Fire, ns: TeamB.Develop, asm: Develop}
       data:
         _damage: 10
-    - rid: 2212115243444469761
-      type: {class: Fire, ns: TeamB.Develop, asm: Develop}
+--- !u!114 &2143643713
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2143643708}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 19a989966fd74c2e816a966b65aa2b2d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _buffData:
+  - rid: 2212115294937939968
+  references:
+    version: 2
+    RefIds:
+    - rid: 2212115294937939968
+      type: {class: BuffManager/BuffData, ns: TeamB.GameSystem, asm: Develop}
       data:
-        _damage: 10
-    - rid: 2212115243444469762
-      type: {class: Fire, ns: TeamB.Develop, asm: Develop}
-      data:
-        _damage: 10
-    - rid: 2212115243444469763
-      type: {class: Fire, ns: TeamB.Develop, asm: Develop}
-      data:
-        _damage: 10
+        BuffType: 0
+        Magnification: 0
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -2172,3 +2385,4 @@ SceneRoots:
   - {fileID: 2143643711}
   - {fileID: 427468182}
   - {fileID: 1352378314}
+  - {fileID: 490317152}

--- a/Assets/Scripts/BaseSystem/Foundation/DataManagement/MasterDatas.cs
+++ b/Assets/Scripts/BaseSystem/Foundation/DataManagement/MasterDatas.cs
@@ -15,7 +15,7 @@ namespace DataManagement
     {
         public override string MasterName => "CharacterMaster";
         /// <summary>
-        /// スキルのデータ
+        /// キャラのデータ
         /// </summary>
         [Serializable]
         public class CharacterData
@@ -24,10 +24,6 @@ namespace DataManagement
             public string Name;
             public string Card;
             public string ResourceName;
-            /// <summary>
-            /// 等級
-            /// </summary>
-            public int Rank;
 
             /// <summary>
             /// HP
@@ -48,7 +44,6 @@ namespace DataManagement
             /// 魔法攻撃力
             /// </summary>
             public float MagicATK;
-            public SkillData Skill;
 
             public CharacterData(SpreadSheet.CharacterData data)
             {
@@ -56,24 +51,13 @@ namespace DataManagement
                 Name = data.Name;
                 Card = data.Card;
                 ResourceName = data.ResourceName;
-                Rank = data.Rank;
                 Hp = data.Hp;
                 HitRate = data.HitRate;
                 ChantingSpeed = data.ChantingSpeed;
                 MagicATK = data.MagicATK;
             }
         }
-
-        /// <summary>
-        /// スキルのデータ
-        /// </summary>
-        [Serializable]
-        public class SkillData
-        {
-            public int Id;
-            public string Text;
-        }
-
+        
         public async UniTask<DataManagement.SpreadSheet.CharacterMaster> LoadFromFile(string masterName = "default")
         {
             if(masterName == "default")

--- a/Assets/Scripts/BaseSystem/Foundation/DataManagement/SpreadSheetDataFormat.cs
+++ b/Assets/Scripts/BaseSystem/Foundation/DataManagement/SpreadSheetDataFormat.cs
@@ -103,12 +103,10 @@ namespace DataManagement
             public string Name;
             public string Card;
             public string ResourceName;
-            public int Rank;
             public float Hp;
             public float HitRate;
             public float ChantingSpeed;
             public float MagicATK;
-            public int SkillId;
 
             public CharacterData(CharacterData data)
             {
@@ -116,7 +114,6 @@ namespace DataManagement
                 Name = data.Name;
                 Card = data.Card;
                 ResourceName = data.ResourceName;
-                Rank = data.Rank;
                 Hp = data.Hp;
                 HitRate = data.HitRate;
                 ChantingSpeed = data.ChantingSpeed;

--- a/Assets/Scripts/Data/CharacterDataManager.cs
+++ b/Assets/Scripts/Data/CharacterDataManager.cs
@@ -17,21 +17,18 @@ namespace TeamB.Data
     [DefaultExecutionOrder(-100)]
     public class CharacterDataManager
     {
-        public event Action OnParamUpdated;
+        public static event Action OnParamUpdated;
 
         private const string filePath = @"Assets\Scripts\Data\CharacterType.cs";
 
         /// <summary> パラメータ更新 </summary>
-        public DataManagement.SpreadSheet.CharacterData UpdateParam(CharacterType characterType,
+        public static DataManagement.SpreadSheet.CharacterData UpdateParam(CharacterType characterType,
             CharacterStatusType paramType, float value)
         {
             if (GameStatics.Characters[(int)characterType] == null)
                 return null;
             switch (paramType)
             {
-                case CharacterStatusType.Rank:
-                    GameStatics.Characters[(int)characterType].Rank += (int)value;
-                    break;
                 case CharacterStatusType.Hp:
                     GameStatics.Characters[(int)characterType].Hp += value;
                     break;
@@ -57,7 +54,8 @@ namespace TeamB.Data
         [RuntimeInitializeOnLoadMethod]
         public static async UniTask MasterDataSetUp()
         {
-            DataManagement.SpreadSheet.CharacterMaster characterData = await new CharacterMaster().LoadFromFile("Character");
+            DataManagement.SpreadSheet.CharacterMaster characterData =
+                await new CharacterMaster().LoadFromFile("Character");
             for (int i = 0; i < characterData.Data.Length; i++)
             {
                 GameStatics.Characters.Add(characterData.Data[i].Id, characterData.Data[i]);
@@ -75,7 +73,6 @@ namespace TeamB.Data
             string playerstatus = $"CharacterData\n" +
                                   $"Name:{GameStatics.Characters[(int)characterType].Name},\n" +
                                   $"HP:{GameStatics.Characters[(int)characterType].Hp}" +
-                                  $"Rank:{GameStatics.Characters[(int)characterType].Rank},\n" +
                                   $"HitRate:{GameStatics.Characters[(int)characterType].HitRate},\n" +
                                   $"ChantingSpeed:{GameStatics.Characters[(int)characterType].ChantingSpeed},\n" +
                                   $"MagicalAmount:{GameStatics.Characters[(int)characterType].MagicATK},\n";
@@ -103,7 +100,6 @@ namespace TeamB.Data
 
     public enum CharacterStatusType
     {
-        Rank,
         Hp,
         HitRate,
         ChantingSpeed,

--- a/Assets/Scripts/Develop/Exam/Ally/AllyManager.cs
+++ b/Assets/Scripts/Develop/Exam/Ally/AllyManager.cs
@@ -2,92 +2,126 @@ using UnityEngine;
 
 namespace TeamB.Develop
 {
-	/// <summary>
-	/// 試験シーンの味方を管理するクラス
-	/// </summary>
-	public class AllyManager : MonoBehaviour, IExam
-	{
-		[SerializeReference, SubclassSelector] private ICharacter _allies;
+    /// <summary>
+    /// 試験シーンの味方を管理するクラス
+    /// </summary>
+    public class AllyManager : MonoBehaviour, IExam
+    {
+        [SerializeReference, SubclassSelector] private IAlly _allies;
 
-		private EnemyManager _enemyManager;
-		private Exam _exam;
-		DefenseInput _defenseInput;
-		AttackInput _attackInput;
+        private EnemyManager _enemyManager;
+        private Exam _exam;
+        DefenseInput _defenseInput = new();
+        AttackInput _attackInput = new();
 
-		public ICharacter GetAllies => _allies;
+        public IAlly GetAllies => _allies;
 
-		private void Awake()
-		{
-			_exam = FindAnyObjectByType<Exam>();
-			Initialized();
-		}
+        private void Awake()
+        {
+            Initialized();
+        }
 
-		private void Initialized()
-		{
-			_enemyManager = FindAnyObjectByType<EnemyManager>();
+        private void Initialized()
+        {
+            _exam = FindAnyObjectByType<Exam>();
+            _enemyManager = FindAnyObjectByType<EnemyManager>();
 
-			_exam.OnExamStarted += OnStartExam;
-			_exam.OnExamEnded += OnEndExam;
-		}
-
-
-		/// <summary>
-		/// 味方の攻撃処理
-		/// </summary>
-		/// <param name="deltaTime"></param>
-		private void AlliesAttack(float deltaTime)
-		{
-			_allies.Attack(_enemyManager.GetCurrentEnemyData, _exam.GetOperationType, deltaTime);
-		}
-
-		public void OnStartExam()
-		{
-			_exam.OnExamUpdated += AlliesAttack;
-			_allies.Initialized();
-			_allies.OnDeath += () => { _exam.EndExam(); };
-		}
-
-		private void OnUpdateExam()
-		{
-			
-		}
-
-		public void OnEndExam()
-		{
-			_exam.OnExamStarted -= OnStartExam;
-			_exam.OnExamEnded -= OnEndExam;
-			_exam.OnExamUpdated -= AlliesAttack;
-			_allies.Dispose();
-		}
-	}
-
-	public enum ActionType
-	{
-		Attack,
-		Defend,
-		None
-	}
+            _exam.OnExamStarted += OnStartExam;
+            _exam.OnExamEnded += OnEndExam;
+        }
 
 
-	public class AttackInput : IInputType
-	{
-		private bool _isInput;
-		public bool IsInput => _isInput;
+        /// <summary>
+        /// 味方の攻撃呼び出し
+        /// </summary>
+        /// <param name="deltaTime"></param>
+        private void AlliesAttack(float deltaTime)
+        {
+            _allies.Attack(_enemyManager.GetCurrentEnemyData, _exam.GetOperationType, deltaTime);
+        }
 
-		public void ChangeInput(bool value)
-		{
-			_isInput = value;
-		}
-	}
+        /// <summary>
+        /// 味方の防御呼び出し
+        /// </summary>
+        /// <param name="deltaTime"></param>
+        private void AlliesDefense(float deltaTime)
+        {
+            _allies.Defense(_exam.GetOperationType, deltaTime);
+        }
 
-	public class DefenseInput : IInputType
-	{
-		private bool _isInput;
-		public bool IsInput => _isInput;
+        /// <summary>
+        /// 試験開始の処理
+        /// </summary>
+        public void OnStartExam()
+        {
+            _exam.OnExamUpdated += OnUpdateExam;
+            _allies.Initialized();
+            _allies.OnDeath += () => { _exam.EndExam(); };
+        }
 
-		public void ChangeInput(bool value)
-		{
-			_isInput = value;
-		}
-	}
+        /// <summary>
+        /// 試験中の処理
+        /// </summary>
+        private void OnUpdateExam(float deltaTime)
+        {
+            //入力受付
+            _attackInput.ChangeInput(Input.GetKeyDown(KeyCode.Space));
+            _defenseInput.ChangeInput(Input.GetKeyDown(KeyCode.Space));
+            _allies.Input(_attackInput, _defenseInput);
+
+            //攻撃の呼び出し
+            AlliesAttack(deltaTime);
+            //防御の呼び出し
+            AlliesDefense(deltaTime);
+        }
+
+        /// <summary>
+        /// 試験終了処理
+        /// </summary>
+        public void OnEndExam()
+        {
+            _exam.OnExamStarted -= OnStartExam;
+            _exam.OnExamEnded -= OnEndExam;
+            _allies.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// 主人公の行動の種類（攻撃、防御）
+    /// </summary>
+    public enum ActionType
+    {
+        Attack,
+        Defend,
+        None
+    }
+
+
+    /// <summary>
+    /// 攻撃の入力管理クラス
+    /// </summary>
+    public class AttackInput : IInputType
+    {
+        private bool _isInput;
+        public bool IsInput => _isInput;
+
+        public void ChangeInput(bool value)
+        {
+            _isInput = value;
+        }
+    }
+
+    /// <summary>
+    /// 防御の入力管理クラス
+    /// </summary>
+    public class DefenseInput : IInputType
+    {
+        private bool _isInput;
+        public bool IsInput => _isInput;
+
+        public void ChangeInput(bool value)
+        {
+            _isInput = value;
+        }
+    }
 }

--- a/Assets/Scripts/Develop/Exam/Ally/AllyManager.cs
+++ b/Assets/Scripts/Develop/Exam/Ally/AllyManager.cs
@@ -2,64 +2,92 @@ using UnityEngine;
 
 namespace TeamB.Develop
 {
-    /// <summary>
-    /// 試験シーンの味方を管理するクラス
-    /// </summary>
-    public class AllyManager : MonoBehaviour
-    {
-        [SerializeReference, SubclassSelector] private ICharacter _allies;
+	/// <summary>
+	/// 試験シーンの味方を管理するクラス
+	/// </summary>
+	public class AllyManager : MonoBehaviour, IExam
+	{
+		[SerializeReference, SubclassSelector] private ICharacter _allies;
 
-        private EnemyManager _enemyManager;
-        private Exam _exam;
+		private EnemyManager _enemyManager;
+		private Exam _exam;
+		DefenseInput _defenseInput;
+		AttackInput _attackInput;
 
-        public ICharacter GetAllies => _allies;
+		public ICharacter GetAllies => _allies;
 
-        private void Awake()
-        {
-            _exam = FindAnyObjectByType<Exam>();
-            Initialized();
-        }
+		private void Awake()
+		{
+			_exam = FindAnyObjectByType<Exam>();
+			Initialized();
+		}
 
-        private void Initialized()
-        {
-            _enemyManager = FindAnyObjectByType<EnemyManager>();
+		private void Initialized()
+		{
+			_enemyManager = FindAnyObjectByType<EnemyManager>();
 
-            _exam.OnExamStarted += OnExamStarted;
-            _exam.OnExamEnded += OnExamEnded;
-        }
+			_exam.OnExamStarted += OnStartExam;
+			_exam.OnExamEnded += OnEndExam;
+		}
 
-        /// <summary>
-        /// 試験開始時処理
-        /// </summary>
-        private void OnExamStarted()
-        {
-            _exam.OnExamUpdated += AlliesAttack;
-            _allies.Initialized();
-            _allies.OnDeath += () =>
-            {
-                _exam.EndExam();
-            };
 
-        }
+		/// <summary>
+		/// 味方の攻撃処理
+		/// </summary>
+		/// <param name="deltaTime"></param>
+		private void AlliesAttack(float deltaTime)
+		{
+			_allies.Attack(_enemyManager.GetCurrentEnemyData, _exam.GetOperationType, deltaTime);
+		}
 
-        /// <summary>
-        /// 試験終了時処理
-        /// </summary>
-        private void OnExamEnded()
-        {
-            _exam.OnExamStarted -= OnExamStarted;
-            _exam.OnExamEnded -= OnExamEnded;
-            _exam.OnExamUpdated -= AlliesAttack;
-            _allies.Dispose();
-        }
+		public void OnStartExam()
+		{
+			_exam.OnExamUpdated += AlliesAttack;
+			_allies.Initialized();
+			_allies.OnDeath += () => { _exam.EndExam(); };
+		}
 
-        /// <summary>
-        /// 味方の攻撃処理
-        /// </summary>
-        /// <param name="deltaTime"></param>
-        private void AlliesAttack(float deltaTime)
-        {
-            _allies.Attack(_enemyManager.GetCurrentEnemyData, deltaTime);
-        }
-    }
+		private void OnUpdateExam()
+		{
+			
+		}
+
+		public void OnEndExam()
+		{
+			_exam.OnExamStarted -= OnStartExam;
+			_exam.OnExamEnded -= OnEndExam;
+			_exam.OnExamUpdated -= AlliesAttack;
+			_allies.Dispose();
+		}
+	}
+
+	public enum ActionType
+	{
+		Attack,
+		Defend,
+		None
+	}
+
+
+	public class AttackInput : IInputType
+	{
+		private bool _isInput;
+		public bool IsInput => _isInput;
+
+		public void ChangeInput(bool value)
+		{
+			_isInput = value;
+		}
+	}
+
+	public class DefenseInput : IInputType
+	{
+		private bool _isInput;
+		public bool IsInput => _isInput;
+
+		public void ChangeInput(bool value)
+		{
+			_isInput = value;
+		}
+	}
 }

--- a/Assets/Scripts/Develop/Exam/Ally/Character1.cs
+++ b/Assets/Scripts/Develop/Exam/Ally/Character1.cs
@@ -1,171 +1,188 @@
 using System;
+using System.Threading;
+using Cysharp.Threading.Tasks;
 using TeamB.Data;
 using TeamB.GameSystem.Statics;
 using UnityEngine;
 
 namespace TeamB.Develop
 {
-	/// <summary>
-	/// キャラクターを管理するクラス : サンプルクラス
-	/// このように実装すれば量産できるよ
-	/// </summary>
-	public class Character1 : IAlly
-	{
-		[SerializeField] private float _percentageReductionValue = 0.75f;
-		[SerializeField] private float _defenceCoolTime = 1f;
+    /// <summary>
+    /// キャラクターを管理するクラス : サンプルクラス
+    /// このように実装すれば量産できるよ
+    /// </summary>
+    public class Character1 : IAlly
+    {
+        [SerializeField] private float _percentageReductionValue = 0.75f;
+        [SerializeField] private float _defenceCoolTime = 1f;
+        [SerializeField] private float _defenceDurationTime = 1f;
 
-		/// <summary> 戦闘用のパラメータ </summary>
-		private DataManagement.SpreadSheet.CharacterData _currentData;
+        /// <summary> 戦闘用のパラメータ </summary>
+        private DataManagement.SpreadSheet.CharacterData _currentData;
 
-		private ActiveType _activeType;
-		private ActionType _actionType;
-		private float _percentageReduction;
-		private float _attackTimer;
-		private float _defenceTimer;
-		private bool _isInputAction;
+        private CancellationToken _token;
 
-		#region Actions
+        private ActionType _actionType;
+        private float _percentageReduction;
+        private float _attackTimer;
+        private float _defenceTimer;
+        private float _defenceDurationTimer;
+        private float _percentageReductionBaseValue = 1;
+        private bool _isAttacking;
+        private bool _isDefending;
+        private bool _isDefenceDuration;
 
-		public event Action OnDeath;
-		public event Action OnAttack;
-		public event Action OnEndAttack;
-		public event Action OnTakeDamage;
-		public event Action OnParamUpDate;
+        #region Actions
 
-		#endregion
+        public event Action OnDeath;
+        public event Action OnAttack;
+        public event Action OnEndAttack;
+        public event Action OnDefence;
+        public event Action OnEndDefence;
+        public event Action OnTakeDamage;
+        public event Action OnParamUpDate;
 
-		// 戦闘用のパラメータ
-		public DataManagement.SpreadSheet.CharacterData GetCurrentData => _currentData;
+        #endregion
 
-		// キャラの種類
-		public CharacterType GetCharacterType => GameStatics.NurturingCharacterType;
+        // 戦闘用のパラメータ
+        public DataManagement.SpreadSheet.CharacterData GetCurrentData => _currentData;
 
-		public ActionType GetActionType => _actionType;
+        // キャラの種類
+        public CharacterType GetCharacterType => GameStatics.NurturingCharacterType;
 
-		public void Initialized()
-		{
-			_actionType = GameStatics.ExamState == ExamState.FirstExam ? ActionType.Defend : ActionType.Attack;
-			_currentData = new(GameStatics.Characters[(int)GameStatics.NurturingCharacterType]);
-			OnParamUpDate?.Invoke();
-		}
+        public ActionType GetActionType => _actionType;
 
-		/// <summary>
-		/// キャラの登録処理
-		/// </summary>
-		/// <param name="type"></param>
-		public void RegistrationType(CharacterType type)
-		{
-			GameStatics.NurturingCharacterType = type;
-		}
+        public void Initialized()
+        {
+            _actionType = GameStatics.ExamState == ExamState.FirstExam ? ActionType.Defend : ActionType.Attack;
+            _currentData = new(GameStatics.Characters[(int)GameStatics.NurturingCharacterType]);
+            _token = new CancellationTokenSource().Token;
+            OnParamUpDate?.Invoke();
+        }
 
-		/// <summary>
-		/// 攻撃処理
-		/// </summary>
-		/// <param name="characters"></param>
-		/// <param name="deltaTime"></param>
-		/// <typeparam name="T"></typeparam>
-		public void Attack<T>(T characters, OperationType operationType, float deltaTime) where T : ICharacter
-		{
-			if (_actionType != ActionType.Attack)
-				return;
+        /// <summary>
+        /// キャラの登録処理
+        /// </summary>
+        /// <param name="type"></param>
+        public void RegistrationType(CharacterType type)
+        {
+            GameStatics.NurturingCharacterType = type;
+            _currentData = new(GameStatics.Characters[(int)GameStatics.NurturingCharacterType]);
+        }
 
-			switch (operationType)
-			{
-				case OperationType.Auto:
-					AutoAttack(characters, deltaTime);
-					break;
-				case OperationType.Manual:
-					ManualAttack(characters, deltaTime);
-					break;
-				case OperationType.None:
-					break;
-			}
-		}
-
-		private void AutoAttack<T>(T characters, float deltaTime) where T : ICharacter
-		{
-			if (_attackTimer >= _currentData.ChantingSpeed)
-			{
-				OnAttack?.Invoke();
-
-				DebugManager.Log(
-					$"{_currentData.Card}は{characters.GetCurrentData.Card}に{_currentData.MagicATK}ダメージ与えた");
-				characters.TakeDamage(_currentData.MagicATK);
-				_attackTimer = 0;
-
-				OnEndAttack?.Invoke();
-			}
-			else
-			{
-				_attackTimer += deltaTime;
-			}
-		}
-
-		private void ManualAttack<T>(T characters, float deltaTime) where T : ICharacter
-		{
-			
-		}
-
-		public void AttackCancel()
-		{
-			
-		}
-
-		/// <summary>
-		/// 攻撃を受ける際の処理
-		/// </summary>
-		/// <param name="damage"></param>
-		public void TakeDamage(float damage)
-		{
-			if (_currentData.Hp <= 0)
-				return;
-
-			//HPの更新
-			_currentData.Hp -= damage * _percentageReduction;
-			OnTakeDamage?.Invoke();
-
-			//死亡時処理
-			if (_currentData.Hp <= 0)
-			{
-				DebugManager.Log($"{_currentData.Card}は敗北した");
-				OnDeath?.Invoke();
-			}
-		}
+        /// <summary>
+        /// 攻撃処理
+        /// </summary>
+        public void Attack<T>(T characters, OperationType operationType, float deltaTime) where T : ICharacter
+        {
+            if (_actionType != ActionType.Attack)
+                return;
 
 
-		public void Dispose()
-		{
-			OnAttack = default;
-			OnDeath = default;
-			OnEndAttack = default;
-			OnTakeDamage = default;
-			OnParamUpDate = default;
-		}
+            if (_attackTimer >= _currentData.ChantingSpeed)
+            {
+                //操作方法が自動時、ゲームプレイヤーの入力を待つ
+                if (operationType == OperationType.Manual && !_isAttacking)
+                    return;
 
-		public void Input()
-		{
-			_isInputAction = true;
-		}
+                OnAttack?.Invoke();
 
-		public void Input(params IInputType[] inputs)
-		{
-			
-		}
+                characters.TakeDamage(_currentData.MagicATK);
+                _attackTimer = 0;
 
-		public void Defense(OperationType operationType, float deltaTime)
-		{
-			if (_actionType != ActionType.Defend)
-				return;
+                OnEndAttack?.Invoke();
+            }
+            else
+            {
+                _attackTimer += deltaTime;
+            }
+        }
 
-			if (_defenceTimer >= _defenceCoolTime)
-			{
-				_percentageReduction = _percentageReductionValue;
-				_defenceTimer = 0;
-			}
-			else
-			{
-				_defenceTimer += deltaTime;
-			}
-		}
-	}
+        public void AttackCancel()
+        {
+        }
+
+        /// <summary>
+        /// 攻撃を受ける際の処理
+        /// </summary>
+        /// <param name="damage"></param>
+        public void TakeDamage(float damage)
+        {
+            if (_currentData.Hp <= 0)
+                return;
+
+            //HPの更新
+            _currentData.Hp -= damage * _percentageReduction;
+            OnTakeDamage?.Invoke();
+
+            DebugManager.Log(
+                $"主人公は{damage * _percentageReduction}ダメージ受けた");
+            //死亡時処理
+            if (_currentData.Hp <= 0)
+            {
+                DebugManager.Log($"{_currentData.Card}は敗北した");
+                OnDeath?.Invoke();
+            }
+        }
+
+
+        public void Dispose()
+        {
+            OnAttack = default;
+            OnDeath = default;
+            OnEndAttack = default;
+            OnTakeDamage = default;
+            OnParamUpDate = default;
+        }
+
+        /// <summary>
+        /// 入力
+        /// </summary>
+        /// <param name="inputs"></param>
+        public void Input(params IInputType[] inputs)
+        {
+            foreach (var input in inputs)
+            {
+                switch (input.GetType().Name)
+                {
+                    case nameof(AttackInput):
+                        _isAttacking = input.IsInput;
+                        break;
+                    case nameof(DefenseInput):
+                        _isDefending = input.IsInput;
+                        break;
+                }
+            }
+        }
+
+        public async void Defense(OperationType operationType, float deltaTime)
+        {
+            if (_actionType != ActionType.Defend)
+                return;
+
+            if (_defenceTimer >= _defenceCoolTime)
+            {
+                //操作方法が手動時、プレイヤーの入力を待つ
+                if (operationType == OperationType.Manual && !_isDefending)
+                    return;
+
+                OnDefence?.Invoke();
+                DebugManager.Log("防御魔法を展開した");
+                _percentageReduction = _percentageReductionValue;
+                _defenceTimer = 0;
+                _isDefenceDuration = true;
+                await UniTask.Delay(TimeSpan.FromSeconds(_defenceDurationTime), DelayType.DeltaTime,
+                    PlayerLoopTiming.Update, _token);
+                _percentageReduction = _percentageReductionBaseValue;
+                _isDefenceDuration = false;
+                DebugManager.Log("防御魔法が消えた");
+
+                OnEndDefence?.Invoke();
+            }
+            else if (!_isDefenceDuration) // 防御魔法の持続時間が切れてから、クールダウン回復
+            {
+                _defenceTimer += deltaTime;
+            }
+        }
+    }
 }

--- a/Assets/Scripts/Develop/Exam/Ally/Character1.cs
+++ b/Assets/Scripts/Develop/Exam/Ally/Character1.cs
@@ -1,106 +1,171 @@
 using System;
+using TeamB.Data;
 using TeamB.GameSystem.Statics;
+using UnityEngine;
 
 namespace TeamB.Develop
 {
-    /// <summary>
-    /// キャラクターを管理するクラス : サンプルクラス
-    /// このように実装すれば量産できるよ
-    /// </summary>
-    public class Character1 : ICharacter
-    {
-        /// <summary> 戦闘用のパラメータ </summary>
-        private DataManagement.SpreadSheet.CharacterData _currentData;
-        private float _attackTimer;
+	/// <summary>
+	/// キャラクターを管理するクラス : サンプルクラス
+	/// このように実装すれば量産できるよ
+	/// </summary>
+	public class Character1 : IAlly
+	{
+		[SerializeField] private float _percentageReductionValue = 0.75f;
+		[SerializeField] private float _defenceCoolTime = 1f;
 
-        #region Actions
-        
-        public event Action OnDeath;
-        public event Action OnAttack;
-        public event Action OnEndAttack;
-        public event Action OnTakeDamage;
-        public event Action OnParamUpDate;
+		/// <summary> 戦闘用のパラメータ </summary>
+		private DataManagement.SpreadSheet.CharacterData _currentData;
 
-        #endregion
-        
-        // 戦闘用のパラメータ
-        public DataManagement.SpreadSheet.CharacterData GetCurrentData => _currentData;
-        // キャラの種類
-        public CharacterType GetCharacterType => GameStatics.NurturingCharacterType;
+		private ActiveType _activeType;
+		private ActionType _actionType;
+		private float _percentageReduction;
+		private float _attackTimer;
+		private float _defenceTimer;
+		private bool _isInputAction;
 
-        public void Initialized()
-        {
-            _currentData =  new (GameStatics.Characters[(int)GameStatics.NurturingCharacterType]);
-            OnParamUpDate?.Invoke();
-        }
+		#region Actions
 
-        /// <summary>
-        /// キャラの登録処理
-        /// </summary>
-        /// <param name="type"></param>
-        public void RegistrationType(CharacterType type)
-        {
-            GameStatics.NurturingCharacterType = type;
-        }
+		public event Action OnDeath;
+		public event Action OnAttack;
+		public event Action OnEndAttack;
+		public event Action OnTakeDamage;
+		public event Action OnParamUpDate;
 
-        /// <summary>
-        /// 攻撃処理
-        /// </summary>
-        /// <param name="characters"></param>
-        /// <param name="deltatime"></param>
-        /// <typeparam name="T"></typeparam>
-        public void Attack<T>(T characters, float deltatime) where T : ICharacter
-        {
-            if (_attackTimer >= _currentData.ChantingSpeed)
-            {
-                OnAttack?.Invoke();
-                
-                DebugManager.Log($"{_currentData.Card}は{characters.GetCurrentData.Card}に{_currentData.MagicATK}ダメージ与えた");
-                characters.TakeDamage(_currentData.MagicATK);
-                _attackTimer = 0;
+		#endregion
 
-                OnEndAttack?.Invoke();
-            }
-            else
-            {
-                _attackTimer += deltatime;
-            }
-        }
+		// 戦闘用のパラメータ
+		public DataManagement.SpreadSheet.CharacterData GetCurrentData => _currentData;
 
-        public void AttackCancel()
-        {
-            
-        }
+		// キャラの種類
+		public CharacterType GetCharacterType => GameStatics.NurturingCharacterType;
 
-        /// <summary>
-        /// 攻撃を受ける際の処理
-        /// </summary>
-        /// <param name="damage"></param>
-        public void TakeDamage(float damage)
-        {
-            if (_currentData.Hp <= 0)
-                return;
+		public ActionType GetActionType => _actionType;
 
-            //HPの更新
-            _currentData.Hp -= damage;
-            OnTakeDamage?.Invoke();
+		public void Initialized()
+		{
+			_actionType = GameStatics.ExamState == ExamState.FirstExam ? ActionType.Defend : ActionType.Attack;
+			_currentData = new(GameStatics.Characters[(int)GameStatics.NurturingCharacterType]);
+			OnParamUpDate?.Invoke();
+		}
 
-            //死亡時処理
-            if (_currentData.Hp <= 0)
-            {
-                DebugManager.Log($"{_currentData.Card}は敗北した");
-                OnDeath?.Invoke();
-            }
-        }
+		/// <summary>
+		/// キャラの登録処理
+		/// </summary>
+		/// <param name="type"></param>
+		public void RegistrationType(CharacterType type)
+		{
+			GameStatics.NurturingCharacterType = type;
+		}
+
+		/// <summary>
+		/// 攻撃処理
+		/// </summary>
+		/// <param name="characters"></param>
+		/// <param name="deltaTime"></param>
+		/// <typeparam name="T"></typeparam>
+		public void Attack<T>(T characters, OperationType operationType, float deltaTime) where T : ICharacter
+		{
+			if (_actionType != ActionType.Attack)
+				return;
+
+			switch (operationType)
+			{
+				case OperationType.Auto:
+					AutoAttack(characters, deltaTime);
+					break;
+				case OperationType.Manual:
+					ManualAttack(characters, deltaTime);
+					break;
+				case OperationType.None:
+					break;
+			}
+		}
+
+		private void AutoAttack<T>(T characters, float deltaTime) where T : ICharacter
+		{
+			if (_attackTimer >= _currentData.ChantingSpeed)
+			{
+				OnAttack?.Invoke();
+
+				DebugManager.Log(
+					$"{_currentData.Card}は{characters.GetCurrentData.Card}に{_currentData.MagicATK}ダメージ与えた");
+				characters.TakeDamage(_currentData.MagicATK);
+				_attackTimer = 0;
+
+				OnEndAttack?.Invoke();
+			}
+			else
+			{
+				_attackTimer += deltaTime;
+			}
+		}
+
+		private void ManualAttack<T>(T characters, float deltaTime) where T : ICharacter
+		{
+			
+		}
+
+		public void AttackCancel()
+		{
+			
+		}
+
+		/// <summary>
+		/// 攻撃を受ける際の処理
+		/// </summary>
+		/// <param name="damage"></param>
+		public void TakeDamage(float damage)
+		{
+			if (_currentData.Hp <= 0)
+				return;
+
+			//HPの更新
+			_currentData.Hp -= damage * _percentageReduction;
+			OnTakeDamage?.Invoke();
+
+			//死亡時処理
+			if (_currentData.Hp <= 0)
+			{
+				DebugManager.Log($"{_currentData.Card}は敗北した");
+				OnDeath?.Invoke();
+			}
+		}
 
 
-        public void Dispose()
-        {
-            OnAttack = default;
-            OnDeath = default;
-            OnEndAttack = default;
-            OnTakeDamage = default;
-            OnParamUpDate = default;
-        }
-    }
+		public void Dispose()
+		{
+			OnAttack = default;
+			OnDeath = default;
+			OnEndAttack = default;
+			OnTakeDamage = default;
+			OnParamUpDate = default;
+		}
+
+		public void Input()
+		{
+			_isInputAction = true;
+		}
+
+		public void Input(params IInputType[] inputs)
+		{
+			
+		}
+
+		public void Defense(OperationType operationType, float deltaTime)
+		{
+			if (_actionType != ActionType.Defend)
+				return;
+
+			if (_defenceTimer >= _defenceCoolTime)
+			{
+				_percentageReduction = _percentageReductionValue;
+				_defenceTimer = 0;
+			}
+			else
+			{
+				_defenceTimer += deltaTime;
+			}
+		}
+	}
 }

--- a/Assets/Scripts/Develop/Exam/Enemy/EnemyManager.cs
+++ b/Assets/Scripts/Develop/Exam/Enemy/EnemyManager.cs
@@ -79,6 +79,9 @@ namespace TeamB.Develop
 		/// </summary>
 		private bool IsAnnihilation() => _currentEnemy.GetCurrentData.Hp <= 0;
 
+		/// <summary>
+		/// 戦闘開始時処理
+		/// </summary>
 		public void OnStartExam()
 		{
 			_currentEnemy.Initialized();
@@ -87,6 +90,9 @@ namespace TeamB.Develop
 			_exam.OnExamUpdated += EnemiesAttack;
 		}
 
+		/// <summary>
+		/// 戦闘終了時処理
+		/// </summary>
 		public void OnEndExam()
 		{
 			_exam.OnExamStarted -= OnStartExam;

--- a/Assets/Scripts/Develop/Exam/Enemy/EnemyManager.cs
+++ b/Assets/Scripts/Develop/Exam/Enemy/EnemyManager.cs
@@ -10,95 +10,89 @@ using Random = UnityEngine.Random;
 
 namespace TeamB.Develop
 {
-    /// <summary>
-    /// 敵側を管理するクラス
-    /// </summary>
-    public class EnemyManager : MonoBehaviour
-    {
-        [SerializeReference, SubclassSelector] private IEnemy _currentEnemy;
-        
-        private WaveManager _waveManager;
-        private AllyManager _allyManager;
-        private Exam _exam;
+	/// <summary>
+	/// 敵側を管理するクラス
+	/// </summary>
+	public class EnemyManager : MonoBehaviour, IExam
+	{
+		[SerializeReference, SubclassSelector] private IEnemy _currentEnemy;
 
-        public IEnemy GetCurrentEnemyData => _currentEnemy;
+		private WaveManager _waveManager;
+		private AllyManager _allyManager;
+		private Exam _exam;
 
-        private void Awake()
-        {
-            Initialized();
-        }
+		public IEnemy GetCurrentEnemyData => _currentEnemy;
 
-
-        /// <summary>
-        /// 初期化処理
-        /// </summary>
-        private void Initialized()
-        {
-            _exam = FindAnyObjectByType<Exam>();
-            _waveManager = FindAnyObjectByType<WaveManager>();
-            _allyManager = FindAnyObjectByType<AllyManager>();
-            if (_exam)
-            {
-                _exam.OnExamStarted += OnExamStart;
-                _exam.OnExamEnded += OnExamEnded;
-            }
-        }
-        
-
-        /// <summary>
-        /// 全敵の攻撃処理
-        /// </summary>
-        /// <param name="deltaTime"></param>
-        private void EnemiesAttack(float deltaTime)
-        {
-            _currentEnemy.Attack(_allyManager.GetAllies, deltaTime);
-        }
-
-        /// <summary>
-        /// 試験開始
-        /// </summary>
-        private void OnExamStart()
-        {
-            _currentEnemy.Initialized();
-            _currentEnemy.OnDeath += OnEnemyDeath;
-            _currentEnemy.OnNextForm += OnNextForm;
-            _exam.OnExamUpdated += EnemiesAttack;
-        }
-
-        /// <summary>
-        /// 試験終了時処理
-        /// </summary>
-        private void OnExamEnded()
-        {
-            _exam.OnExamStarted -= OnExamStart;
-            _exam.OnExamEnded -= OnExamEnded;
-            _exam.OnExamUpdated -= EnemiesAttack;
-            _currentEnemy.Dispose();
-        }
-
-        /// <summary>
-        /// 生徒会長が負けた時
-        /// </summary>
-        private void OnEnemyDeath()
-        {
-            DebugManager.Log($"{_currentEnemy.GetCurrentData.Card}に勝った");
-            GameStatics.ExamState = ExamState.SecondExam;
-            _exam.EndExam();
-        }
-
-        /// <summary>
-        /// 形態変化時
-        /// </summary>
-        private void OnNextForm()
-        {
-            _waveManager.NextWave();
-            
-        }
+		private void Awake()
+		{
+			Initialized();
+		}
 
 
-        /// <summary>
-        /// 敵が全滅しているか
-        /// </summary>
-        private bool IsAnnihilation() => _currentEnemy.GetCurrentData.Hp <= 0;
-    }
+		/// <summary>
+		/// 初期化処理
+		/// </summary>
+		private void Initialized()
+		{
+			_exam = FindAnyObjectByType<Exam>();
+			_waveManager = FindAnyObjectByType<WaveManager>();
+			_allyManager = FindAnyObjectByType<AllyManager>();
+			if (_exam)
+			{
+				_exam.OnExamStarted += OnStartExam;
+				_exam.OnExamEnded += OnEndExam;
+			}
+		}
+
+
+		/// <summary>
+		/// 全敵の攻撃処理
+		/// </summary>
+		/// <param name="deltaTime"></param>
+		private void EnemiesAttack(float deltaTime)
+		{
+			_currentEnemy.Attack(_allyManager.GetAllies, _exam.GetOperationType,  deltaTime);
+		}
+
+
+		/// <summary>
+		/// 生徒会長が負けた時
+		/// </summary>
+		private void OnEnemyDeath()
+		{
+			DebugManager.Log($"{_currentEnemy.GetCurrentData.Card}に勝った");
+			GameStatics.ExamState = ExamState.SecondExam;
+			_exam.EndExam();
+		}
+
+		/// <summary>
+		/// 形態変化時
+		/// </summary>
+		private void OnNextForm()
+		{
+			_waveManager.NextWave();
+		}
+
+
+		/// <summary>
+		/// 敵が全滅しているか
+		/// </summary>
+		private bool IsAnnihilation() => _currentEnemy.GetCurrentData.Hp <= 0;
+
+		public void OnStartExam()
+		{
+			_currentEnemy.Initialized();
+			_currentEnemy.OnDeath += OnEnemyDeath;
+			_currentEnemy.OnNextForm += OnNextForm;
+			_exam.OnExamUpdated += EnemiesAttack;
+		}
+
+		public void OnEndExam()
+		{
+			_exam.OnExamStarted -= OnStartExam;
+			_exam.OnExamEnded -= OnEndExam;
+			_exam.OnExamUpdated -= EnemiesAttack;
+			_currentEnemy.Dispose();
+		}
+	}
 }

--- a/Assets/Scripts/Develop/Exam/Enemy/StudentCouncilPresident.cs
+++ b/Assets/Scripts/Develop/Exam/Enemy/StudentCouncilPresident.cs
@@ -36,18 +36,23 @@ namespace TeamB.Develop
 			_currentData = new(GameStatics.Characters[(int)_characterType]);
 		}
 
+		/// <summary>
+		/// 外からキャラのデータを変更する関数
+		/// </summary>
 		public void RegistrationType(CharacterType type)
 		{
 			_characterType = type;
+			_currentData = new(GameStatics.Characters[(int)_characterType]);
 		}
 
+		/// <summary>
+		/// 攻撃処理
+		/// </summary>
 		public void Attack<T>(T characters, OperationType _, float deltaTime) where T : ICharacter
 		{
 			if (_attackTimer >= _currentData.ChantingSpeed)
 			{
 				OnAttack?.Invoke();
-				DebugManager.Log(
-					$"{_currentData.Card}は{characters.GetCurrentData.Card}に{_currentData.MagicATK}ダメージ与えた");
 				characters.TakeDamage(_currentData.MagicATK);
 				_attackTimer = 0;
 
@@ -59,6 +64,10 @@ namespace TeamB.Develop
 			}
 		}
 
+		/// <summary>
+		/// 受ダメージ処理
+		/// </summary>
+		/// <param name="damage"></param>
 		public void TakeDamage(float damage)
 		{
 			if (_currentData.Hp <= 0)
@@ -68,6 +77,8 @@ namespace TeamB.Develop
 			_currentData.Hp -= damage;
 			OnTakeDamage?.Invoke();
 
+			DebugManager.Log(
+				$"生徒会長は{damage}ダメージ受けた");
 			//形態変化
 			if (_currentData.Hp <= GameStatics.Characters[(int)_characterType].Hp / GameConsts.MaxWave *
 			    (GameConsts.MaxWave - GetCurrentForm) && _currentData.Hp > 0)

--- a/Assets/Scripts/Develop/Exam/Enemy/StudentCouncilPresident.cs
+++ b/Assets/Scripts/Develop/Exam/Enemy/StudentCouncilPresident.cs
@@ -9,92 +9,92 @@ using TeamB.GameSystem.Statics;
 
 namespace TeamB.Develop
 {
-    /// <summary>
-    /// 生徒会長の行動を管理するクラス
-    /// </summary>
-    public class StudentCouncilPresident : IEnemy
-    {
-        [SerializeField] CharacterType _characterType;
+	/// <summary>
+	/// 生徒会長の行動を管理するクラス
+	/// </summary>
+	public class StudentCouncilPresident : IEnemy
+	{
+		[SerializeField] CharacterType _characterType;
 
-        private DataManagement.SpreadSheet.CharacterData _currentData;
-        private float _attackTimer;
-        private int _currentForm = 1;
+		private DataManagement.SpreadSheet.CharacterData _currentData;
+		private float _attackTimer;
+		private int _currentForm = 1;
 
-        public event Action OnDeath;
-        public event Action OnAttack;
-        public event Action OnEndAttack;
-        public event Action OnTakeDamage;
-        public event Action OnParamUpdate;
-        public event Action OnNextForm;
+		public event Action OnDeath;
+		public event Action OnAttack;
+		public event Action OnEndAttack;
+		public event Action OnTakeDamage;
+		public event Action OnParamUpdate;
+		public event Action OnNextForm;
 
-        public DataManagement.SpreadSheet.CharacterData GetCurrentData => _currentData;
-        public CharacterType GetCharacterType => _characterType;
-        public int GetCurrentForm => _currentForm;
+		public DataManagement.SpreadSheet.CharacterData GetCurrentData => _currentData;
+		public CharacterType GetCharacterType => _characterType;
+		public int GetCurrentForm => _currentForm;
 
-        public void Initialized()
-        {
-            _currentData = new(GameStatics.Characters[(int)_characterType]);
-        }
+		public void Initialized()
+		{
+			_currentData = new(GameStatics.Characters[(int)_characterType]);
+		}
 
-        public void RegistrationType(CharacterType type)
-        {
-            _characterType = type;
-        }
+		public void RegistrationType(CharacterType type)
+		{
+			_characterType = type;
+		}
 
-        public void Attack<T>(T characters, float deltatime) where T : ICharacter
-        {
-            if (_attackTimer >= _currentData.ChantingSpeed)
-            {
-                OnAttack?.Invoke();
-                DebugManager.Log(
-                    $"{_currentData.Card}は{characters.GetCurrentData.Card}に{_currentData.MagicATK}ダメージ与えた");
-                characters.TakeDamage(_currentData.MagicATK);
-                _attackTimer = 0;
+		public void Attack<T>(T characters, OperationType _, float deltaTime) where T : ICharacter
+		{
+			if (_attackTimer >= _currentData.ChantingSpeed)
+			{
+				OnAttack?.Invoke();
+				DebugManager.Log(
+					$"{_currentData.Card}は{characters.GetCurrentData.Card}に{_currentData.MagicATK}ダメージ与えた");
+				characters.TakeDamage(_currentData.MagicATK);
+				_attackTimer = 0;
 
-                OnEndAttack?.Invoke();
-            }
-            else
-            {
-                _attackTimer += deltatime;
-            }
-        }
+				OnEndAttack?.Invoke();
+			}
+			else
+			{
+				_attackTimer += deltaTime;
+			}
+		}
 
-        public void TakeDamage(float damage)
-        {
-            if (_currentData.Hp <= 0)
-                return;
+		public void TakeDamage(float damage)
+		{
+			if (_currentData.Hp <= 0)
+				return;
 
-            //HPの更新
-            _currentData.Hp -= damage;
-            OnTakeDamage?.Invoke();
+			//HPの更新
+			_currentData.Hp -= damage;
+			OnTakeDamage?.Invoke();
 
-            //形態変化
-            if (_currentData.Hp <= GameStatics.Characters[(int)_characterType].Hp / GameConsts.MaxWave *
-                (GameConsts.MaxWave - GetCurrentForm) && _currentData.Hp > 0)
-            {
-                _currentForm++;
-                OnNextForm?.Invoke();
-            }
+			//形態変化
+			if (_currentData.Hp <= GameStatics.Characters[(int)_characterType].Hp / GameConsts.MaxWave *
+			    (GameConsts.MaxWave - GetCurrentForm) && _currentData.Hp > 0)
+			{
+				_currentForm++;
+				OnNextForm?.Invoke();
+			}
 
-            //死亡時処理
-            if (_currentData.Hp <= 0)
-            {
-                OnDeath?.Invoke();
-            }
-        }
+			//死亡時処理
+			if (_currentData.Hp <= 0)
+			{
+				OnDeath?.Invoke();
+			}
+		}
 
-        public void AttackCancel()
-        {
-        }
+		public void AttackCancel()
+		{
+		}
 
-        public void Dispose()
-        {
-            OnDeath = default;
-            OnParamUpdate = default;
-            OnAttack = default;
-            OnTakeDamage = default;
-            OnEndAttack = default;
-            OnNextForm = default;
-        }
-    }
+		public void Dispose()
+		{
+			OnDeath = default;
+			OnParamUpdate = default;
+			OnAttack = default;
+			OnTakeDamage = default;
+			OnEndAttack = default;
+			OnNextForm = default;
+		}
+	}
 }

--- a/Assets/Scripts/Develop/Exam/Exam.cs
+++ b/Assets/Scripts/Develop/Exam/Exam.cs
@@ -15,10 +15,10 @@ namespace TeamB.Develop
     /// 試験シーン全体を管理するクラス
     /// </summary>
     [DefaultExecutionOrder(100)]
-    public class Exam : MonoBehaviour, IPose
+    public class Exam : MonoBehaviour
     {
         [SerializeField] private float _examTime = 45f;
-        private OperationType _operationType;
+        [SerializeField]　private OperationType _operationType;
         private float _currentTimer = 0f;
         public event Action OnExamStarted;
         public event Action<float> OnExamUpdated;
@@ -28,14 +28,13 @@ namespace TeamB.Develop
         public float GetCurrentTimer => _currentTimer;
         public float GetMaxTime => _examTime;
 
-        private async void Awake()
+        private void Awake()
         {
             StartExam();
         }
 
         private void Update()
         {
-            
             OnExamUpdated?.Invoke(Time.deltaTime);
         }
 
@@ -59,6 +58,14 @@ namespace TeamB.Develop
         }
 
         /// <summary>
+        /// 操作方法の変更
+        /// </summary>
+        public void ChangeOperation()
+        {
+            _operationType = _operationType == OperationType.Auto ? OperationType.Manual : OperationType.Auto;
+        }
+
+        /// <summary>
         /// 時間管理
         /// </summary>
         /// <param name="deltaTime"></param>
@@ -74,24 +81,20 @@ namespace TeamB.Develop
                 _currentTimer += Time.deltaTime;
             }
         }
-
-        public void InPose()
-        {
-            
-        }
-
-        public void OutPose()
-        {
-            
-        }
     }
 
+    /// <summary>
+    /// Managerクラスでスタートとエンドをすぐ作る用
+    /// </summary>
     interface IExam
     {
         public void OnStartExam();
         public void OnEndExam();
     }
 
+    /// <summary>
+    /// 操作方法の種類（自動、手動）
+    /// </summary>
     public enum OperationType
     {
         Auto,

--- a/Assets/Scripts/Develop/Exam/Exam.cs
+++ b/Assets/Scripts/Develop/Exam/Exam.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using Codice.Client.Common.Threading;
 using DataManagement;
 using TeamB.Data;
 using TeamB.GameSystem;
@@ -14,14 +15,16 @@ namespace TeamB.Develop
     /// 試験シーン全体を管理するクラス
     /// </summary>
     [DefaultExecutionOrder(100)]
-    public class Exam : MonoBehaviour
+    public class Exam : MonoBehaviour, IPose
     {
         [SerializeField] private float _examTime = 45f;
+        private OperationType _operationType;
         private float _currentTimer = 0f;
         public event Action OnExamStarted;
         public event Action<float> OnExamUpdated;
         public event Action OnExamEnded;
 
+        public OperationType GetOperationType => _operationType;
         public float GetCurrentTimer => _currentTimer;
         public float GetMaxTime => _examTime;
 
@@ -32,6 +35,7 @@ namespace TeamB.Develop
 
         private void Update()
         {
+            
             OnExamUpdated?.Invoke(Time.deltaTime);
         }
 
@@ -70,5 +74,28 @@ namespace TeamB.Develop
                 _currentTimer += Time.deltaTime;
             }
         }
+
+        public void InPose()
+        {
+            
+        }
+
+        public void OutPose()
+        {
+            
+        }
+    }
+
+    interface IExam
+    {
+        public void OnStartExam();
+        public void OnEndExam();
+    }
+
+    public enum OperationType
+    {
+        Auto,
+        Manual,
+        None
     }
 }

--- a/Assets/Scripts/Develop/Exam/ICharacter.cs
+++ b/Assets/Scripts/Develop/Exam/ICharacter.cs
@@ -57,28 +57,33 @@ namespace TeamB.Develop
 		public void Dispose();
 	}
 
+	/// <summary>
+	/// 味方クラスが継承するべきインターフェース
+	/// </summary>
 	public interface IAlly : ICharacter
 	{
 		public ActionType GetActionType { get; }
 
 		public void Input(params IInputType[] inputs);
 
+		/// <summary>
+		/// 
+		/// </summary>
 		public void Defense(OperationType operationType, float deltaTime);
 	}
 
+	/// <summary>
+	/// 敵クラスが継承するべきインターフェース
+	/// </summary>
 	public interface IEnemy : ICharacter
 	{
 		public event Action OnNextForm;
 		public int GetCurrentForm { get; }
 	}
 
-	public enum ActiveType
-	{
-		Active,
-		InActive,
-		None
-	}
-
+	/// <summary>
+	/// 入力クラスを作成する時に継承する（paramを使うためのインターフェース）
+	/// </summary>
 	public interface IInputType
 	{
 		public bool IsInput { get; }

--- a/Assets/Scripts/Develop/Exam/ICharacter.cs
+++ b/Assets/Scripts/Develop/Exam/ICharacter.cs
@@ -5,63 +5,82 @@ using DataManagement.SpreadSheet;
 
 namespace TeamB.Develop
 {
-    /// <summary>
-    /// 戦闘キャラ用のインターフェース
-    /// </summary>
-    public interface ICharacter
-    {
-        public CharacterType GetCharacterType { get; }
-        public DataManagement.SpreadSheet.CharacterData GetCurrentData { get; }
-        
-        
-        #region Actions
+	/// <summary>
+	/// 戦闘キャラ用のインターフェース
+	/// </summary>
+	public interface ICharacter
+	{
+		public CharacterType GetCharacterType { get; }
+		public DataManagement.SpreadSheet.CharacterData GetCurrentData { get; }
 
-        public event Action OnDeath;
-        public event Action OnAttack;
-        public event Action OnEndAttack;
-        public event Action OnTakeDamage;
 
-        #endregion
+		#region Actions
 
-        /// <summary>
-        /// 初期化処理
-        /// </summary>
-        public void Initialized();
-        
-        /// <summary>
-        /// キャラの登録処理
-        /// </summary>
-        /// <param name="type"></param>
-        /// <typeparam name="T"></typeparam>
-        public void RegistrationType(CharacterType type);
+		public event Action OnDeath;
+		public event Action OnAttack;
+		public event Action OnEndAttack;
+		public event Action OnTakeDamage;
 
-        /// <summary>
-        /// 攻撃処理
-        /// </summary>
-        /// <param name="characters"></param>
-        /// <param name="deltatime"></param>
-        /// <typeparam name="T"></typeparam>
-        public void Attack<T>(T characters, float deltatime) where T : ICharacter;
-        
-        public void AttackCancel();
+		#endregion
 
-        /// <summary>
-        /// ダメージ受ける処理
-        /// </summary>
-        /// <param name="damage"></param>
-        public void TakeDamage(float damage);
+		/// <summary>
+		/// 初期化処理
+		/// </summary>
+		public void Initialized();
 
-        /// <summary>
-        /// 試験終了後に行う処理
-        /// </summary>
-        public void Dispose();
-    }
+		/// <summary>
+		/// キャラの登録処理
+		/// </summary>
+		/// <param name="type"></param>
+		/// <typeparam name="T"></typeparam>
+		public void RegistrationType(CharacterType type);
 
-    public interface IEnemy : ICharacter
-    {
-        public event Action OnNextForm;
-        public int GetCurrentForm { get; }
-    }
+		/// <summary>
+		/// 攻撃処理
+		/// </summary>
+		/// <param name="characters"></param>
+		/// <param name="deltaTime"></param>
+		/// <typeparam name="T"></typeparam>
+		public void Attack<T>(T characters, OperationType operationType, float deltaTime) where T : ICharacter;
 
-    
+		public void AttackCancel();
+
+		/// <summary>
+		/// ダメージ受ける処理
+		/// </summary>
+		/// <param name="damage"></param>
+		public void TakeDamage(float damage);
+
+		/// <summary>
+		/// 試験終了後に行う処理
+		/// </summary>
+		public void Dispose();
+	}
+
+	public interface IAlly : ICharacter
+	{
+		public ActionType GetActionType { get; }
+
+		public void Input(params IInputType[] inputs);
+
+		public void Defense(OperationType operationType, float deltaTime);
+	}
+
+	public interface IEnemy : ICharacter
+	{
+		public event Action OnNextForm;
+		public int GetCurrentForm { get; }
+	}
+
+	public enum ActiveType
+	{
+		Active,
+		InActive,
+		None
+	}
+
+	public interface IInputType
+	{
+		public bool IsInput { get; }
+	}
 }

--- a/Assets/Scripts/Develop/Exam/Skill/SkillManager.cs
+++ b/Assets/Scripts/Develop/Exam/Skill/SkillManager.cs
@@ -1,122 +1,174 @@
 using System;
 using TeamB.Data;
+using TeamB.GameSystem.Statics;
 using UnityEngine;
 
 namespace TeamB.Develop
 {
-    /// <summary>
-    /// スキルを管理するクラス
-    /// </summary>
-    public class SkillManager : MonoBehaviour
-    {
-        [SerializeField] private SkillData[] skillData;
-        [SerializeField] private float _maxCost;
+	/// <summary>
+	/// スキルを管理するクラス
+	/// </summary>
+	public class SkillManager : MonoBehaviour, IExam
+	{
+		[SerializeField] private SkillData[] _skillData;
+		[SerializeField] private float _maxCost;
 
-        [SerializeField, Header("1秒に回復するコストの量")]
-        private float _recoveryCost;
+		[SerializeField, Header("1秒に回復するコストの量")]
+		private float _recoveryCost;
 
-        private EnemyManager _enemyManager;
-        private AllyManager _allyManager;
-        private Exam _exam;
-        private float _currentHaveCost;
+		private EnemyManager _enemyManager;
+		private AllyManager _allyManager;
+		private Exam _exam;
+		private float _currentHaveCost;
 
-        public event Action OnCostRecovery;
+		public event Action OnCostRecovery;
 
-        public SkillData[] GetSkillData => skillData;
-        public float GetCurrentHaveCost => _currentHaveCost;
-        public float GetMaxCost => _maxCost;
+		public SkillData[] GetSkillData => _skillData;
+		public float GetCurrentHaveCost => _currentHaveCost;
+		public float GetMaxCost => _maxCost;
 
 
-        [Serializable]
-        public class SkillData
-        {
-            [SerializeField] public ExamState _examState;
-            [SerializeField] public SkillState[] _skillState;
+		[Serializable]
+		public class SkillData
+		{
+			[SerializeField] public ExamState _examState;
+			[SerializeField] public SkillState[] _skillState;
 
-            [Serializable]
-            public class SkillState
-            {
-                public SkillType SkillType;
-                [SerializeReference, SubclassSelector] public ISkill Skill;
-                public Target Target;
-                public float Cost;
-            }
-        }
+			[Serializable]
+			public class SkillState
+			{
+				public SkillType SkillType;
+				[SerializeReference, SubclassSelector] public ISkill Skill;
+				public Target Target;
+				public float Cost;
+			}
+		}
 
-        private void Awake()
-        {
-            _enemyManager = FindAnyObjectByType<EnemyManager>();
-            _allyManager = FindAnyObjectByType<AllyManager>();
-            _exam = FindAnyObjectByType<Exam>();
-            _exam.OnExamUpdated += CostRecovery;
-        }
+		private void Awake()
+		{
+			_enemyManager = FindAnyObjectByType<EnemyManager>();
+			_allyManager = FindAnyObjectByType<AllyManager>();
+			_exam = FindAnyObjectByType<Exam>();
+			_exam.OnExamStarted += OnStartExam;
+			_exam.OnExamEnded += OnEndExam;
+		}
 
-        /// <summary>
-        /// 対象を探す
-        /// </summary>
-        /// <param name="target"></param>
-        /// <returns></returns>
-        public ICharacter TargetSelect(Target target)
-        {
-            switch (target)
-            {
-                case Target.Character:
-                    return _allyManager.GetAllies;
-                case Target.Enemy:
-                    return _enemyManager.GetCurrentEnemyData;
-                default:
-                    return null;
-            }
-        }
+		public void ActivationSkill(SkillType skillType)
+		{
+			var info = SearchSkill(skillType);
+			if (GetCurrentHaveCost >= info.cost)
+			{
+				info.skill.Activation(TargetSelect(info.target));
+				CostDecrease(info.cost);
+			}
+		}
 
-        public void CostDecrease(float　consumptionCost)
-        {
-            _currentHaveCost -= consumptionCost;
-        }
+		/// <summary>
+		/// スキル種類からスキル、対象、コストを得る
+		/// </summary>
+		/// <param name="skillType"></param>
+		/// <returns></returns>
+		(ISkill skill, Target target, float cost) SearchSkill(SkillType skillType)
+		{
+			ISkill skill;
+			Target target;
+			float cost;
+			for (int i = 0; i < GetSkillData.Length; i++)
+			{
+				for (int n = 0; n < GetSkillData[i]._skillState.Length; n++)
+				{
+					if (GetSkillData[i]._examState == GameStatics.ExamState &&
+					    GetSkillData[i]._skillState[n].SkillType == skillType)
+					{
+						skill = GetSkillData[i]._skillState[n].Skill;
+						target = GetSkillData[i]._skillState[n].Target;
+						cost = GetSkillData[i]._skillState[n].Cost;
+						return (skill, target, cost);
+					}
+				}
+			}
 
-        private void CostRecovery(float deltaTime)
-        {
-            if (_currentHaveCost >= _maxCost)
-                return;
-            _currentHaveCost += _recoveryCost * deltaTime;
-            OnCostRecovery?.Invoke();
+			return (null, Target.None, 0f);
+		}
 
-            if (_currentHaveCost >= _maxCost)
-            {
-                _currentHaveCost = _maxCost;
-            }
-        }
-    }
 
-    /// <summary>
-    /// スキルを実装する時に継承するクラス
-    /// </summary>
-    public interface ISkill
-    {
-        public event Action OnChantingSkill;
+		/// <summary>
+		/// 対象を探す
+		/// </summary>
+		/// <param name="target"></param>
+		/// <returns></returns>
+		public ICharacter TargetSelect(Target target)
+		{
+			switch (target)
+			{
+				case Target.Character:
+					return _allyManager.GetAllies;
+				case Target.Enemy:
+					return _enemyManager.GetCurrentEnemyData;
+				default:
+					return null;
+			}
+		}
 
-        /// <summary>
-        /// スキル発動
-        /// </summary>
-        /// <param name="character"></param>
-        public void Activation(ICharacter character);
-    }
+		public void CostDecrease(float consumptionCost)
+		{
+			_currentHaveCost -= consumptionCost;
+		}
 
-    public enum SkillType
-    {
-        Fire,
-        Blizzard,
-        Wind,
-        Water,
-        Heal,
-        Barrier,
-        None
-    }
+		private void CostRecovery(float deltaTime)
+		{
+			if (_currentHaveCost >= _maxCost)
+				return;
+			_currentHaveCost += _recoveryCost * deltaTime;
+			OnCostRecovery?.Invoke();
 
-    public enum Target
-    {
-        Character,
-        Enemy,
-        None
-    }
+			if (_currentHaveCost >= _maxCost)
+			{
+				_currentHaveCost = _maxCost;
+			}
+		}
+
+		public void OnStartExam()
+		{
+			_exam.OnExamUpdated += CostRecovery;
+		}
+
+		public void OnEndExam()
+		{
+			_exam.OnExamStarted -= OnStartExam;
+			_exam.OnExamUpdated -= CostRecovery;
+		}
+	}
+
+	/// <summary>
+	/// スキルを実装する時に継承するクラス
+	/// </summary>
+	public interface ISkill
+	{
+		public event Action OnChantingSkill;
+
+		/// <summary>
+		/// スキル発動
+		/// </summary>
+		/// <param name="character"></param>
+		public void Activation(ICharacter character);
+	}
+
+	public enum SkillType
+	{
+		Fire,
+		Blizzard,
+		Wind,
+		Water,
+		Heal,
+		Barrier,
+		None
+	}
+
+	public enum Target
+	{
+		Character,
+		Enemy,
+		None
+	}
 }

--- a/Assets/Scripts/Develop/UI/InExamUIView.cs
+++ b/Assets/Scripts/Develop/UI/InExamUIView.cs
@@ -5,6 +5,7 @@ using TeamB.GameSystem.Statics;
 using TeamB.InGameData.Data;
 using UISystem;
 using UnityEngine;
+using UnityEngine.Serialization;
 using UnityEngine.UI;
 
 namespace TeamB.UI
@@ -16,9 +17,9 @@ namespace TeamB.UI
     {
         [SerializeField] private Text _soulText;
         [SerializeField] private Text _waveText;
-        [SerializeField] private Text _TimerText;
+        [SerializeField] private Text _timerText;
+        [SerializeField] private Text _operationText;
         
-        SoulManager _soulManager;
         WaveManager _waveManager;
         Exam _exam;
             
@@ -50,12 +51,6 @@ namespace TeamB.UI
             _waveManager.OnNextWave += WaveText;
             _exam.OnExamUpdated += TimerText;
         }
-
-        public void SoulText()
-        {
-            DebugManager.Log(_soulManager.GetCurrentSoul);
-            _soulText.text = $"回収した魂{_soulManager.GetCurrentSoul.ToString("00")}個";
-        }
         public void WaveText()
         {
             DebugManager.Log(_waveManager.GetCurrentWave);
@@ -63,7 +58,12 @@ namespace TeamB.UI
         }
         public void TimerText(float _)
         {
-            _TimerText.text = $"残り{(_exam.GetMaxTime - _exam.GetCurrentTimer).ToString("F2")}秒";
+            _timerText.text = $"残り{(_exam.GetMaxTime - _exam.GetCurrentTimer).ToString("F2")}秒";
+        }
+
+        public void OperationChange()
+        {
+            _operationText.text = _exam.GetOperationType == OperationType.Auto ? "Auto" : "Manual";
         }
     }
 }

--- a/Assets/Scripts/Develop/UI/InResultView.cs
+++ b/Assets/Scripts/Develop/UI/InResultView.cs
@@ -10,20 +10,24 @@ namespace TeamB.Develop
     public class InResultView : UIView
     {
         [SerializeField] UnityEngine.UI.Text _text;
+        private string _passedSentence = "合格";
+        private string _notPassedSentence = "不合格";
+        Vector3 _startScale = new Vector3(300, 300, 300);
+        private float _stampTime = 1.5f;
 
         private void Start()
         {
             if (GameStatics.ExamState == ExamState.FirstExam)
             {
-                _text.text = "不合格";
+                _text.text = _passedSentence;
             }
             else
             {
-                _text.text = "合格";
+                _text.text = _notPassedSentence;
             }
 
-            _text.GetComponent<RectTransform>().transform.DOScale(new Vector3(300, 300, 300), 0f);
-            _text.GetComponent<RectTransform>().transform.DOScale(Vector3.one, 1.5f).SetEase(Ease.OutCirc);
+            _text.GetComponent<RectTransform>().transform.DOScale(_startScale, 0f);
+            _text.GetComponent<RectTransform>().transform.DOScale(Vector3.one, _stampTime).SetEase(Ease.OutCirc);
         }
 
         public void Result()

--- a/Assets/Scripts/Develop/UI/SkillButtonUI.cs
+++ b/Assets/Scripts/Develop/UI/SkillButtonUI.cs
@@ -9,57 +9,22 @@ using UnityEngine.UI;
 
 namespace TeamB.Develop
 {
-    /// <summary>
-    /// スキルのボタンを管理するクラス
-    /// </summary>
-    public class SkillButtonUI : MonoBehaviour
-    {
-        [SerializeField] SkillType _skillType;
-        private (ISkill skill, Target target, float cost) info;
-        SkillManager manager;
+	/// <summary>
+	/// スキルのボタンを管理するクラス
+	/// </summary>
+	public class SkillButtonUI : MonoBehaviour
+	{
+		[SerializeField] SkillType _skillType;
+		SkillManager _manager;
 
-        private void Awake()
-        {
-            manager = FindAnyObjectByType<SkillManager>();
-            info = SearchSkill(_skillType);
-        }
+		private void Awake()
+		{
+			_manager = FindAnyObjectByType<SkillManager>();
+		}
 
-        public void ButtonClick()
-        {
-            if (manager.GetCurrentHaveCost >= info.cost)
-            {
-                info.skill.Activation(manager.TargetSelect(info.target));
-                manager.CostDecrease(info.cost);
-            }
-        }
-
-
-        /// <summary>
-        /// スキル種類からスキル、対象、コストを得る
-        /// </summary>
-        /// <param name="skillType"></param>
-        /// <returns></returns>
-        (ISkill skill, Target target, float cost) SearchSkill(SkillType skillType)
-        {
-            ISkill skill;
-            Target target;
-            float cost;
-            for (int i = 0; i < manager.GetSkillData.Length; i++)
-            {
-                for (int n = 0; n < manager.GetSkillData[i]._skillState.Length; n++)
-                {
-                    if (manager.GetSkillData[i]._examState == GameStatics.ExamState &&
-                        manager.GetSkillData[i]._skillState[n].SkillType == skillType)
-                    {
-                        skill = manager.GetSkillData[i]._skillState[n].Skill;
-                        target = manager.GetSkillData[i]._skillState[n].Target;
-                        cost = manager.GetSkillData[i]._skillState[n].Cost;
-                        return (skill, target, cost);
-                    }
-                }
-            }
-
-            return (null, Target.None, 0f);
-        }
-    }
+		public void ButtonClick()
+		{
+			_manager.ActivationSkill(_skillType);
+		}
+	}
 }

--- a/Assets/Scripts/GameSystem/PoseManager.cs
+++ b/Assets/Scripts/GameSystem/PoseManager.cs
@@ -11,19 +11,25 @@ public class PoseManager : MonoBehaviour
 {
     public event Action OnInPose;
     public event Action OnOutPose;
+    
+    private bool _isInPose;
+    
+    public bool GetIsInPose => _isInPose;
 
     public void StartPose()
     {
         OnInPose?.Invoke();
+        _isInPose = true;
     }
 
     public void StopPose()
     {
         OnOutPose?.Invoke();
+        _isInPose = false;
     }
 }
 
-/// <summary> ポーズ時に処理するクラスに継承する </summary>
+/// <summary> ポーズするオブジェクトがクラスに継承する </summary>
 public interface IPose
 {
     public void InPose();


### PR DESCRIPTION
# 変更点・追加した機能の概要

<!-- タスクのURL。なければ次の行を削除してください -->
Notion: https://www.notion.so/1-2-583eacf6079445f0a3df2ef35da027f2?pvs=4
https://www.notion.so/Auto-Manual-1a37512559184f63bd237a3a8dd11d08?pvs=4

<!-- レビュアーが理解できるよう、このプルリクの概要と共に、どうしておこなったかの背景が以下に書かれているとグッド -->
・攻撃と防御の切り替え
　・１次試験では防御、２次試験では攻撃
・操作方法の切り替え（自動、手動）
　・攻撃と防御を自動、手動で実行できるようにした
・主人公パラメータ数の更新
　・等級がいらなくなったので消した


# 影響範囲・懸念点

<!-- レビュアーに見てほしい点、影響しそうな機能 -->


# おこなった動作確認

<!-- おこなった動作確認を箇条書きで。Scene名や行った操作のフローなど -->
* [ 1]GameLaunterから、Examを実行
* [2]Autoと書かれてるボタンを押したら、手動操作になる。逆もしかり
* [3]１次試験では防御、２次試験では攻撃になるが、１次試験のクリア条件を変更してないので２次試験に行かない 


# その他

<!-- レビュアーへのメッセージや一言などあれば -->